### PR TITLE
Pass cloudmapNamespaceFlag to discovery in main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ func main() {
 
 	cfg := discovery.SDConfig{
 		RefreshInterval: *refreshIntervalFlag,
+		CloudmapNamespace: cloudmapNamespaceFlag,
 	}
 	sess, err := session.NewSession()
 	if err != nil {


### PR DESCRIPTION
## Expected Behavior

It discovers services from the specified namespace if provide `--cloudmap.namespace` flag.

## Actual Behavior

It discovers services from all namespaces regardless `--cloudmap.namespace` flag.

## Description

CloudmapNamespace is defined and used in `pkg/discovery/discovery.go` but it not passed to SDConfig in main.go.
In this pull request, I added the code that uses the flag. The result was the expected behavior.